### PR TITLE
Only add newline if a shebang or flow header was found

### DIFF
--- a/license-fixer.js
+++ b/license-fixer.js
@@ -107,7 +107,8 @@ LicenseFixer.prototype.getLicenseForFile = function getLicenseForFile(file) {
 LicenseFixer.prototype.fixContent = function fixContent(file, content) {
     var preamble = '';
     // Check for shebang
-    if (content.match(/^#!|#\s*(en)?coding=/m)) {
+    var foundShebang = content.match(/^#!|#\s*(en)?coding=/m);
+    if (foundShebang) {
         var shebangIndex = content.indexOf('\n');
         if (shebangIndex >= 0) {
             preamble += content.slice(0, shebangIndex + 1);
@@ -116,14 +117,18 @@ LicenseFixer.prototype.fixContent = function fixContent(file, content) {
     }
 
     // check for @flow header
-    if (content.match(/^\/\/ @flow|^\/\* @flow \*\//m)) {
+    var foundFlowHeader = content.match(/^\/\/ @flow|^\/\* @flow \*\//m);
+    if (foundFlowHeader) {
         var flowIndex = content.indexOf('\n');
         if (flowIndex >= 0) {
             preamble += content.slice(0, flowIndex + 1);
             content = content.slice(flowIndex + 1).trim() + '\n';
         }
     }
-    preamble += '\n';
+
+    if (foundShebang || foundFlowHeader) {
+        preamble += '\n';
+    }
 
     // Remove old licenses
     for (var i = 0; i < this.licenseExpressions.length; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -38,8 +38,8 @@ tape('add-header', function (t) {
 	var outputFileContent = fs.readFileSync(path.join(fixturePath, 'output.js'), 'utf8');
 
 	// remove the dynamic year portion of the header comment
-	var consistantOutputString = outputFileContent.substring(outputFileContent.indexOf('Permission'));
-	var outputRegex = new RegExp(esc(consistantOutputString));
+	var consistentOutputString = "^".concat(esc(outputFileContent).replace(new RegExp(/\d{4}/), "\\d{4}"));
+	var outputRegex = new RegExp(consistentOutputString);
 
 	temp.mkdir('add-header', function(mkTempErr, dirPath) {
 	  if (mkTempErr) {
@@ -73,12 +73,12 @@ tape('add-nonstandard-header', function (t) {
 	var output3FileContent = fs.readFileSync(path.join(fixturePath, 'output-3.js'), 'utf8');
 
 	// remove the dynamic year portion of the header comment
-	var consistantOutputString = output1FileContent.substring(output1FileContent.indexOf('Permission'));
-	var output1Regex = new RegExp(esc(consistantOutputString));
-	consistantOutputString = output2FileContent.substring(output2FileContent.indexOf('Permission'));
-	var output2Regex = new RegExp(esc(consistantOutputString));
-	consistantOutputString = output3FileContent.substring(output3FileContent.indexOf('Permission'));
-	var output3Regex = new RegExp(esc(consistantOutputString));
+	var consistentOutputString = "^".concat(esc(output1FileContent).replace(new RegExp(/\d{4}/), "\\d{4}"));
+	var output1Regex = new RegExp(consistentOutputString);
+	consistentOutputString = "^".concat(esc(output2FileContent).replace(new RegExp(/\d{4}/), "\\d{4}"));
+	var output2Regex = new RegExp(consistentOutputString);
+	consistentOutputString = "^".concat(esc(output3FileContent).replace(new RegExp(/\d{4}/), "\\d{4}"));
+	var output3Regex = new RegExp(consistentOutputString);
 
 	temp.mkdir('add-header', function(mkTempErr, dirPath) {
 	  if (mkTempErr) {
@@ -111,8 +111,8 @@ tape('dont-add-header', function (t) {
 	var outputFileContent = fs.readFileSync(path.join(fixturePath, 'output.js'), 'utf8');
 
 	// remove the dynamic year portion of the header comment
-	var consistantOutputString = outputFileContent.substring(outputFileContent.indexOf('Permission'));
-	var outputRegex = new RegExp(esc(consistantOutputString));
+	var consistentOutputString = "^".concat(esc(outputFileContent).replace(new RegExp(/\d{4}/), "\\d{4}"));
+	var outputRegex = new RegExp(consistentOutputString);
 
 	temp.mkdir('dont-add-header', function(mkTempErr, dirPath) {
 	  if (mkTempErr) {
@@ -125,6 +125,7 @@ tape('dont-add-header', function (t) {
 	  		throw execErr;
 	  	}
 			var inputFileContent = fs.readFileSync('input.js', 'utf8');
+
 			t.true(outputRegex.test(inputFileContent), 'should prepend header');
 			t.end();
 		});


### PR DESCRIPTION
This PR address #27 by only inserting a newline into the preamble of files that begin with a shebang or flow header. It also updates the tests so that such a case can be caught in the future. Previously, the tests stripped the start of the output files until "Permission". I changed the tests to instead escape the entire output file and then replace the year with a regular expression matching four digits.